### PR TITLE
Add support for Keybase webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Synapse Rapid Power-up for interacting with third-party services through webhooks.
 
-Currently supports Discord, Slack, and Microsoft Teams.
+Currently supports Discord, Slack, Keybase and Microsoft Teams.
 
 ## Install
 

--- a/storm/modules/zw.webhook.privsep.storm
+++ b/storm/modules/zw.webhook.privsep.storm
@@ -2,7 +2,7 @@
 $__varsPrefix = "zw.webhook:entry"
 
 // Valid services
-$__validServices = $lib.set("discord", "slack", "teams")
+$__validServices = $lib.set("discord", "slack", "teams", "keybase")
 
 // Fatal error
 function __error(mesg) {
@@ -23,6 +23,10 @@ function __detectWebhookService(url) {
 
     if ($url.find("discord.com") != $lib.null) {
         return(discord)
+    }
+
+    if ($url.find("keybase.io") != $lib.null) {
+        return(keybase)
     }
 
     if ($url.find("office") != $lib.null or $url.find("microsoft") != $lib.null) {
@@ -103,6 +107,20 @@ function doTeamsWebhook(url, mesg, verify_ssl) {
     }
 }
 
+// Make a Keybase-style webhook call
+function doKeybaseWebhook(url, mesg, verify_ssl) {
+    $mesgTrunc = $mesg.slice(0, 10000)
+    if ($mesg != $mesgTrunc) {
+        $lib.warn("Truncating message to 10000 characters")
+    }
+
+    $resp = $lib.inet.http.post($url, json=({"msg": $mesgTrunc}), ssl_verify=$verify_ssl)
+
+    if (not ($resp.code >= 200 and $resp.code < 300)) {
+        $lib.warn(`Error sending Keybase webhook message: {$resp}`)
+    }
+}
+
 // Call a webhook
 function callWebhook(name, mesg, defang, verify_ssl) {
     $key = $__getGlobalsKey($name)
@@ -128,6 +146,7 @@ function callWebhook(name, mesg, defang, verify_ssl) {
         "discord": { $doDiscordWebhook($entry.url, $mesg, $verify_ssl) }
         "slack": { $doSlackWebhook($entry.url, $mesg, $verify_ssl) }
         "teams": { $doTeamsWebhook($entry.url, $mesg, $verify_ssl) }
+        "keybase": { $doKeybaseWebhook($entry.url, $mesg, $verify_ssl) }
         *: { $__error(`Unsupported webhook service for {$name}: {$entry.service}`) }
     }
 

--- a/synapse-webhook.yaml
+++ b/synapse-webhook.yaml
@@ -1,7 +1,7 @@
 name: zw-webhook
-version: 1.0.2
+version: 1.0.3
 synapse_minversion: [2, 129, 0]
-desc: The zw-webhook package provides commands to interact with common third-party messaging platforms (Slack, Teams, and Discord) through their webhook APIs.
+desc: The zw-webhook package provides commands to interact with common third-party messaging platforms (Slack, Teams, Discord and Keybase) through their webhook APIs.
 
 author:
   url: https://zanderwork.com/
@@ -32,7 +32,7 @@ commands:
       - - --service
         - type: str
           default: auto
-          help: "Service to use this webhook for. If unset (or set to auto), service is determined based on webhook URL. Valid options are: auto, discord, slack, teams."
+          help: "Service to use this webhook for. If unset (or set to auto), service is determined based on webhook URL. Valid options are: auto, discord, slack, teams, keybase."
       - - --global
         - type: bool
           default: false

--- a/test_synapse_webhook.py
+++ b/test_synapse_webhook.py
@@ -96,6 +96,30 @@ class TeamsApiMock(s_httpapi.Handler):
                 return
 
         raise ValueError("bad teams webhook")
+    
+class KeybaseApiMock(s_httpapi.Handler):
+    """Mock implementation of a Keybase webhook server."""
+
+    counter = 0
+
+    async def head(self):
+        raise NotImplementedError
+
+    async def get(self):
+        raise NotImplementedError
+
+    async def post(self):
+        if self.request.body:
+            d = json.loads(self.request.body.decode())
+            m = d.get("msg")
+            if m is not None:
+                check_defang(m)
+                
+                KeybaseApiMock.counter += 1
+                self.set_status(200)
+                return
+
+        raise ValueError("bad keybase webhook")
 
 class SynapseWebhookTest(s_test.SynTest):
     async def _t_install_pkg(self, core: s_cortex.Cortex, prox: s_cortex.CoreApi | None = None):
@@ -120,10 +144,11 @@ class SynapseWebhookTest(s_test.SynTest):
             self.stormIsInPrint("Webhook added for service \"discord\"", await core.stormlist("zw.webhook.add asdf1 https://discord.com/api/webhooks/1111223423432/asdflkjsadlfkjadslfjlkfdsa-lkjczlknvznnmvxzc-oireoiwqrwoiuqroiweiuqorq"))
             self.stormIsInPrint("Webhook added for service \"slack\"", await core.stormlist("zw.webhook.add asdf2 https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"))
             self.stormIsInPrint("Webhook added for service \"teams\"", await core.stormlist("zw.webhook.add asdf3 https://asdfsafda.webhook.office.com/asdfasdfsafdsa/zxcvxzvxzvcxv/gdgfdsgfdsgfdg"))
+            self.stormIsInPrint("Webhook added for service \"keybase\"", await core.stormlist("zw.webhook.add asdf4 https://bots.keybase.io/webhookbot/asdasdasdasda_asdasdasdasda"))
             self.stormIsInErr("Failed to detect webhook service", await core.stormlist("zw.webhook.add asdf3 https://reddit.com"))
-            self.stormIsInErr("Invalid service specified: zzz", await core.stormlist("zw.webhook.add --service zzz asdf4 https://reddit.com"))
-            self.stormIsInPrint("Webhook added for service \"teams\"", await core.stormlist("zw.webhook.add --service teams asdf4 https://reddit.com"))
-            self.stormIsInErr("A webhook already exists", await core.stormlist("zw.webhook.add --service teams asdf4 https://reddit.com"))
+            self.stormIsInErr("Invalid service specified: zzz", await core.stormlist("zw.webhook.add --service zzz asdf5 https://reddit.com"))
+            self.stormIsInPrint("Webhook added for service \"teams\"", await core.stormlist("zw.webhook.add --service teams asdf5 https://reddit.com"))
+            self.stormIsInErr("A webhook already exists", await core.stormlist("zw.webhook.add --service teams asdf5 https://reddit.com"))
 
     async def test_call(self):
         async with self.getTestCoreAndProxy() as (core, prox):
@@ -137,10 +162,12 @@ class SynapseWebhookTest(s_test.SynTest):
             core.addHttpApi("/discord", DiscordApiMock, {"cell": core})
             core.addHttpApi("/slack", SlackApiMock, {"cell": core})
             core.addHttpApi("/teams", TeamsApiMock, {"cell": core})
+            core.addHttpApi("/keybase", KeybaseApiMock, {"cell": core})
 
             await core.callStorm(f"zw.webhook.add --service discord d1 https://root:root@127.0.0.1:{port}/discord")
             await core.callStorm(f"zw.webhook.add --service slack --global s1 https://root:root@127.0.0.1:{port}/slack")
             await core.callStorm(f"zw.webhook.add --service teams t1 https://root:root@127.0.0.1:{port}/teams")
+            await core.callStorm(f"zw.webhook.add --service teams k1 https://root:root@127.0.0.1:{port}/keybase")
 
             self.stormHasNoWarnErr(await core.stormlist("zw.webhook.send --no-verify d1 hello"))
             self.eq(DiscordApiMock.counter, 1)
@@ -163,6 +190,13 @@ class SynapseWebhookTest(s_test.SynTest):
             self.stormHasNoWarnErr(await core.stormlist("[inet:url=http://google.com inet:url=http://bing.com] | zw.webhook.send --no-verify --defang t1 `defang {$node.value()}`"))
             self.eq(TeamsApiMock.counter, 5)
 
+            self.stormHasNoWarnErr(await core.stormlist("zw.webhook.send --no-verify k1 hello"))
+            self.eq(KeybaseApiMock.counter, 1)
+            self.stormHasNoWarnErr(await core.stormlist("[inet:url=http://google.com inet:url=http://bing.com] | zw.webhook.send --no-verify k1 `{$node.value()}`"))
+            self.eq(KeybaseApiMock.counter, 3)
+            self.stormHasNoWarnErr(await core.stormlist("[inet:url=http://google.com inet:url=http://bing.com] | zw.webhook.send --no-verify --defang k1 `defang {$node.value()}`"))
+            self.eq(KeybaseApiMock.counter, 5)
+
             async with core.getLocalProxy(user="nopriv") as noprivcore:
                 self.stormIsInErr("Not authorized to use", [m async for m in noprivcore.storm("zw.webhook.send --no-verify d1 yeet")])
                 self.stormHasNoWarnErr([m async for m in noprivcore.storm("zw.webhook.send --no-verify s1 yeet")])
@@ -178,12 +212,14 @@ class SynapseWebhookTest(s_test.SynTest):
             self.stormIsInPrint("Webhook added for service \"discord\"", await core.stormlist("zw.webhook.add asdf1 https://discord.com/api/webhooks/1111223423432/asdflkjsadlfkjadslfjlkfdsa-lkjczlknvznnmvxzc-oireoiwqrwoiuqroiweiuqorq"))
             self.stormIsInPrint("Webhook added for service \"slack\"", await core.stormlist("zw.webhook.add asdf2 https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"))
             self.stormIsInPrint("Webhook added for service \"teams\"", await core.stormlist("zw.webhook.add asdf3 https://asdfsafda.webhook.office.com/asdfasdfsafdsa/zxcvxzvxzvcxv/gdgfdsgfdsgfdg"))
+            self.stormIsInPrint("Webhook added for service \"keybase\"", await core.stormlist("zw.webhook.add asdf4 https://bots.keybase.io/webhookbot/asdasdasdasda_asdasdasdasda"))
 
             mesgs = await core.stormlist("zw.webhook.list")
             self.stormHasNoWarnErr(mesgs)
             self.stormIsInPrint("Webhook: asdf1", mesgs)
             self.stormIsInPrint("Webhook: asdf2", mesgs)
             self.stormIsInPrint("Webhook: asdf3", mesgs)
+            self.stormIsInPrint("Webhook: asdf4", mesgs)
             
             async with core.getLocalProxy(user="nopriv") as noprivcore:
                 self.stormIsInErr("Not allowed to list", [m async for m in noprivcore.storm("zw.webhook.list --all")])
@@ -198,6 +234,7 @@ class SynapseWebhookTest(s_test.SynTest):
             self.stormIsInPrint("Webhook added for service \"discord\"", await core.stormlist("zw.webhook.add asdf1 https://discord.com/api/webhooks/1111223423432/asdflkjsadlfkjadslfjlkfdsa-lkjczlknvznnmvxzc-oireoiwqrwoiuqroiweiuqorq"))
             self.stormIsInPrint("Webhook added for service \"slack\"", await core.stormlist("zw.webhook.add asdf2 https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"))
             self.stormIsInPrint("Webhook added for service \"teams\"", await core.stormlist("zw.webhook.add asdf3 https://asdfsafda.webhook.office.com/asdfasdfsafdsa/zxcvxzvxzvcxv/gdgfdsgfdsgfdg"))
+            self.stormIsInPrint("Webhook added for service \"keybase\"", await core.stormlist("zw.webhook.add asdf4 https://bots.keybase.io/webhookbot/asdasdasdasda_asdasdasdasda"))
 
             self.stormIsInPrint("Webhook deleted: asdf1", await core.stormlist("zw.webhook.delete asdf1"))
             

--- a/test_synapse_webhook.py
+++ b/test_synapse_webhook.py
@@ -167,7 +167,7 @@ class SynapseWebhookTest(s_test.SynTest):
             await core.callStorm(f"zw.webhook.add --service discord d1 https://root:root@127.0.0.1:{port}/discord")
             await core.callStorm(f"zw.webhook.add --service slack --global s1 https://root:root@127.0.0.1:{port}/slack")
             await core.callStorm(f"zw.webhook.add --service teams t1 https://root:root@127.0.0.1:{port}/teams")
-            await core.callStorm(f"zw.webhook.add --service teams k1 https://root:root@127.0.0.1:{port}/keybase")
+            await core.callStorm(f"zw.webhook.add --service keybase k1 https://root:root@127.0.0.1:{port}/keybase")
 
             self.stormHasNoWarnErr(await core.stormlist("zw.webhook.send --no-verify d1 hello"))
             self.eq(DiscordApiMock.counter, 1)


### PR DESCRIPTION
Added a few lines to add support for Keybase webhooks (Keybase-managed only, you can self-host bots on your own FQDN but I didn't add support for that _yet_)